### PR TITLE
use Fastly-Key instead of X-Fastly-Key

### DIFF
--- a/fastly_slurper/slurper.py
+++ b/fastly_slurper/slurper.py
@@ -47,7 +47,7 @@ class Fastly(requests.Session):
         super(Fastly, self).__init__()
 
         self.headers.update({
-            'X-Fastly-Key': api_key,
+            'Fastly-Key': api_key,
             'User-Agent': self.user_agent,
         })
 


### PR DESCRIPTION
The use of `X-Fastly-Key` is deprecated and will not be supported long term. This branch replaces any occurrences of `X-Fastly-Key` with `Fastly-Key`.
